### PR TITLE
Expand the range of supported pg versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postgres",
     "postgresql"
   ],
-  "version": "0.0.10",
+  "version": "0.0.11",
   "engines": {
     "node": ">=0.6.0"
   },
@@ -42,7 +42,7 @@
     "sinon": "^1.14.1"
   },
   "peerDependencies": {
-    "pg": "^4.3.0"
+    "pg": ">=4.3.0 <7.0.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha test"


### PR DESCRIPTION
pg versions between between 5.x and 6.x will stop being reported as incompatible by npm 3